### PR TITLE
ci: Add Workflow to Check Pull Request Title

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -1,0 +1,19 @@
+name: "Pull Request Tasks"
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-pr-title:
+    name: Check Pull Request Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR Title
+        uses: deepakputhraya/action-pr-title@v1.0.2
+        with:
+          allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: " # title should start with the given prefix


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Actions workflow to automate tasks when a pull request is created or updated. The workflow includes a job to check the pull request title against a set of allowed prefixes.

Key changes:

* Added a new GitHub Actions workflow file `.github/workflows/pull-request-tasks.yml` to automate tasks for pull requests.
* Configured the workflow to trigger on pull request events such as opened, edited, and synchronized.
* Set permissions for the workflow to read contents and write pull requests.
* Added a job named `check-pr-title` that uses the `deepakputhraya/action-pr-title@v1.0.2` GitHub Action to validate the pull request title against specified allowed prefixes.

Fixes #15 