### PR TITLE
chore: Sync Labels with Repository

### DIFF
--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -1,0 +1,83 @@
+# Default GitHub labels
+- color: d73a4a
+  name: bug
+  description: Something isn't working
+- color: 0075ca
+  name: documentation
+  description: Improvements or additions to documentation
+- color: 0366d6
+  name: dependencies
+  description: Pull requests that update a dependency file
+- color: cfd3d7
+  name: duplicate
+  description: This issue or pull request already exists
+- color: a2eeef
+  name: enhancement
+  description: Functionality that enhances existing features
+- color: 7057ff
+  name: good first issue
+  description: Good for newcomers
+- color: 008672
+  name: help wanted
+  description: We are looking for community help
+- color: e4e669
+  name: invalid
+  description: This doesn't seem right
+- color: d876e3
+  name: question
+  description: Further information is requested
+- color: d876e3
+  name: wontfix
+  description: The issue is expected and will not be fixed
+# Release Please
+- color: ededed
+  name: "autorelease: pending"
+  description: The release is pending and awaiting further actions
+- color: ededed
+  name: "autorelease: tagged"
+  description: The release has been tagged
+- color: ededed
+  name: "autorelease: triggered"
+  description: A release has been triggered but not yet completed
+- color: ededed
+  name: "autorelease: snapshot"
+  description: A snapshot release that is not intended for production
+- color: ededed
+  name: "autorelease: published"
+  description: A release has been published
+# Languages
+- color: ffffff
+  name: swift
+  description: Pull requests that update Swift code
+- color: 000000
+  name: github_actions
+  description: Pull requests that update GitHub Actions code
+- color: 66A615
+  name: just
+  description: Pull requests that update Just code
+- color: 00ff44
+  name: shell
+  description: Pull requests that update Shell code
+# Components
+- color: ff0073
+  name: git_hooks
+  description: Pull requests that update git hooks
+# Sizes
+- color: 00ff22
+  name: size/XS
+  description: Extra Small Pull Request
+- color: 03a319
+  name: size/S
+  description: Small Pull Request
+- color: f2bb05
+  name: size/M
+  description: Medium Pull Request
+- color: fc7e08
+  name: size/L
+  description: Large Pull Request
+- color: ad2e03
+  name: size/XL
+  description: Extra Large Pull Request
+- color: 751f01
+  name: size/XXL
+  description: Extra Extra Large Pull Request

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,27 @@
+name: "Sync labels"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/other-configurations/labels.yml
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  configure-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Sync labels
+        uses: micnncim/action-label-syncer@v1.3.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          manifest: .github/other-configurations/labels.yml


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces new GitHub label configurations and a workflow to synchronize these labels automatically. The most important changes include the addition of default GitHub labels, release-related labels, language-specific labels, component-specific labels, and size-specific labels, as well as the creation of a workflow to keep these labels in sync.

### Label Configuration Additions:

* Added default GitHub labels such as `bug`, `documentation`, `dependencies`, and more to `.github/other-configurations/labels.yml`.
* Introduced release-related labels like `autorelease: pending`, `autorelease: tagged`, and others.
* Included language-specific labels such as `swift`, `github_actions`, `just`, and `shell`.
* Added component-specific labels like `git_hooks`.
* Defined size-specific labels ranging from `size/XS` to `size/XXL`.

### Workflow Creation:

* Created a new workflow `.github/workflows/sync-labels.yml` to automatically synchronize labels using the `micnncim/action-label-syncer` GitHub Action.

Fixes #16 