### PR TITLE
ci: Apply Labels to Pull Requests

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -1,0 +1,36 @@
+# labels auto-assigned to PR, keep in sync with labels.yml
+documentation:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["README.md", "docs/**"]
+dependencies:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["**/poetry.lock"]
+      - head-branch: ["^dependabot"]
+swift:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["*.swift", "**/*.swift"]
+just:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["Justfile", "**/*.just"]
+shell:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["**/*.sh"]
+github_actions:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              [
+                ".github/workflows/*",
+                ".github/workflows/**/*",
+                ".github/actions/*",
+                ".github/actions/**/*",
+              ]
+git_hooks:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["githooks/**"]

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -17,3 +17,29 @@ jobs:
         uses: deepakputhraya/action-pr-title@v1.0.2
         with:
           allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: " # title should start with the given prefix
+
+  labeller:
+    name: Label Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label Pull Request
+        uses: actions/labeler@v5.0.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/other-configurations/labeller.yml
+          sync-labels: true
+
+      - name: Add Size Labels
+        uses: pascalgn/size-label-action@v0.5.5
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          sizes: >
+            {
+              "0": "XS",
+              "40": "S",
+              "100": "M",
+              "200": "L",
+              "800": "XL",
+              "2000": "XXL"
+            }


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new labeling system for pull requests and adds a job to automatically apply these labels based on the changes in the pull request. The most important changes include the addition of a configuration file for auto-labeling and updating the workflow to include a labeling job.

Labeling system:

* [`.github/other-configurations/labeller.yml`](diffhunk://#diff-b490f987d9b055ce6e06e37d13763d61f6e0d5ee349b390bbb910f8d88ff36b9R1-R36): Added a configuration file to define labels based on changed files, head branches, and other criteria.

Workflow updates:

* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfR20-R45): Added a new job named `labeller` to label pull requests automatically using the `actions/labeler` and `pascalgn/size-label-action`.

Fixes #17 