### PR TITLE
ci: Upgrade Markdown Link Checker

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -40,14 +40,14 @@ jobs:
 
   check-markdown-links:
     name: Check Markdown links
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.2.4
+        uses: UmbrellaDocs/action-linkspector@v1.2.5
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes an update to the `.github/workflows/code-checks.yml` file to ensure the latest environment and tool versions are used for checking Markdown links.

Updates to environment and tools:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L43-R50): Changed the `runs-on` parameter from `ubuntu-22.04` to `ubuntu-latest` to use the latest available Ubuntu environment.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L43-R50): Updated the `UmbrellaDocs/action-linkspector` action from version `v1.2.4` to `v1.2.5` to use the latest version of the tool.