### PR TITLE
ci: Rename GitHub Actions Steps

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -19,7 +19,7 @@ jobs:
     name: Check Code Quality
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,7 +15,7 @@ jobs:
   configure-labels:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes minor updates to the `jobs:` sections in the GitHub workflows for code checks and label synchronization. The changes involve renaming the step for checking out the repository.

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L22-R22): Renamed the step from "Checkout" to "Checkout Repository" for clarity.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L18-R18): Renamed the step from "Checkout" to "Checkout Repository" for consistency.