### PR TITLE
chore: Add Dependabot Configuration to Upgrade Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
+    target-branch: "main"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new configuration file for Dependabot to automate dependency updates for GitHub Actions. The key changes include specifying the update schedule, target branch, and grouping patterns for updates.

Dependabot configuration:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R17): Added a new configuration file to automate GitHub Actions dependency updates with a weekly schedule on Saturdays at 01:00 AM in the Europe/London timezone.

Fixes #18
