### PR TITLE
chore: Remove Swift Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,19 +15,3 @@ updates:
         update-types:
           - "patch"
           - "minor"
-
-  - package-ecosystem: "swift"
-    directory: "/GitHubPulse/GitHubPulseApp.swift"
-    schedule:
-      interval: "weekly"
-      day: "saturday"
-      time: "01:00"
-      timezone: "Europe/London"
-    target-branch: "main"
-    groups:
-      swift:
-        patterns:
-          - "*"
-        update-types:
-          - "patch"
-          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `.github/dependabot.yml` file to remove the update configuration for Swift packages. The most important change is the removal of the Swift package update schedule.

Configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L18-L33): Removed the Swift package update configuration, including the schedule, target branch, and update types.