### PR TITLE
chore: Update Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "saturday"
+      interval: "daily"
       time: "01:00"
       timezone: "Europe/London"
     target-branch: "main"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the Dependabot configuration file to update the frequency of dependency checks.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L6-R6): Changed the schedule interval for GitHub Actions dependency updates from "weekly" on "saturday" to "daily" at "01:00" in the "Europe/London" timezone.