### PR TITLE
chore: Update Labels

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -1,8 +1,23 @@
-# labels auto-assigned to PR, keep in sync with labels.yml
+# labels auto assigned to PR, keep in sync with labels.yml
+# Type
 documentation:
   - any:
       - changed-files:
           - any-glob-to-any-file: ["README.md", "*.md", "docs/**"]
+dependencies:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["**/uv.lock", "package-lock.json"]
+      - head-branch: ["^dependabot"]
+configurations:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              [
+                ".github/other-configurations/*",
+                ".github/super-linter-configurations/*",
+              ]
+# Language
 markdown:
   - any:
       - changed-files:
@@ -13,28 +28,33 @@ markdown:
                 "LICENSE",
                 ".github/pull_request_template.md",
               ]
-dependencies:
+python:
   - any:
       - changed-files:
-          - any-glob-to-any-file: ["**/poetry.lock"]
-      - head-branch: ["^dependabot"]
-swift:
+          - any-glob-to-any-file: ["*.py", "**/*.py"]
+typescript:
   - any:
       - changed-files:
-          - any-glob-to-any-file: ["*.swift", "**/*.swift"]
-just:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file: ["Justfile", "**/*.just"]
+          - any-glob-to-any-file:
+              ["*.ts", "*.tsx", "**/*.ts", "**/*.tsx", "**/tsconfig.json"]
 shell:
   - any:
       - changed-files:
           - any-glob-to-any-file: ["**/*.sh"]
+just:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["Justfile", "**/*.just"]
+swift:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["*.swift", "**/*.swift"]
+# Components
+git_hooks:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["lefthook.yml"]
 github_actions:
   - any:
       - changed-files:
           - any-glob-to-any-file: [".github/workflows/*", ".github/actions/*"]
-git_hooks:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file: ["githooks/**"]

--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -2,6 +2,9 @@
 - color: d73a4a
   name: bug
   description: Something isn't working
+- color: fef2c0
+  name: configurations
+  description: Pull requests that update configuration files
 - color: 0075ca
   name: documentation
   description: Improvements or additions to documentation
@@ -46,21 +49,27 @@
   name: "autorelease: published"
   description: A release has been published
 # Languages
-- color: ffffff
-  name: swift
-  description: Pull requests that update Swift code
 - color: 000000
   name: github_actions
   description: Pull requests that update GitHub Actions code
-- color: 66A615
-  name: just
-  description: Pull requests that update Just code
 - color: 00ff44
   name: shell
   description: Pull requests that update Shell code
 - color: 1900ff
   name: markdown
   description: Pull requests that update Markdown documentation
+- color: 66A615
+  name: just
+  description: Pull requests that update Just code
+- color: 2b67c6
+  name: python
+  description: Pull requests that update Python code
+- color: 00ff1e
+  name: typescript
+  description: Pull requests that update TypeScript code
+- color: ffffff
+  name: swift
+  description: Pull requests that update Swift code
 # Components
 - color: ff0073
   name: git_hooks


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/other-configurations/labeller.yml` and `.github/other-configurations/labels.yml` files to enhance the labeling system for pull requests. The main changes include adding new labels for different types of files and configurations, and updating the existing labels to ensure better categorization.

Enhancements to labeling system:

* Added new labels for dependencies, configurations, Python, TypeScript, and Shell files in `.github/other-configurations/labeller.yml`. [[1]](diffhunk://#diff-b490f987d9b055ce6e06e37d13763d61f6e0d5ee349b390bbb910f8d88ff36b9L1-R20) [[2]](diffhunk://#diff-b490f987d9b055ce6e06e37d13763d61f6e0d5ee349b390bbb910f8d88ff36b9L16-R60)
* Updated the `dependencies` label to only include `uv.lock` and `package-lock.json` files and head branches starting with `dependabot` in `.github/other-configurations/labeller.yml`.
* Added new label descriptions for configurations, Python, TypeScript, and Just code in `.github/other-configurations/labels.yml`. [[1]](diffhunk://#diff-c1b32711b0f3da3f5c7007cfaa4d9e94ae5430fea1f4e1256f6210bc6988553dR5-R7) [[2]](diffhunk://#diff-c1b32711b0f3da3f5c7007cfaa4d9e94ae5430fea1f4e1256f6210bc6988553dL49-R72)
* Restored the `swift` and `just` labels with updated colors and descriptions in `.github/other-configurations/labels.yml`.