### PR TITLE
chore: Update Markdown Link Checker

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -51,13 +51,14 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.2.5
+        uses: UmbrellaDocs/action-linkspector@v1.3.1
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
           reporter: github-pr-review
           fail_on_error: true
           filter_mode: nofilter
+          show_stats: true
 
   check-justfile-format:
     name: Check Justfile Format


### PR DESCRIPTION

# Pull Request

## Description

This pull request includes a minor update to the `.github/workflows/code-checks.yml` file. The change updates the version of the `UmbrellaDocs/action-linkspector` action and adds a new configuration option.

- Updated the `UmbrellaDocs/action-linkspector` action from version `v1.2.5` to `v1.3.1` and added the `show_stats` configuration option to the Markdown links check job.