### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/other-configurations/pinact.yml
+++ b/.github/other-configurations/pinact.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+ignore_actions:
+  - name: actions/.*
+    ref: .*
+  - name: github/codeql-action/.*
+    ref: .*

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.3.0
+        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.1
+        uses: UmbrellaDocs/action-linkspector@c6d4525e9f50b27a0e78fc42b537141058d034ef # v1.3.1
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -70,7 +70,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
       - name: Check Justfile Format
         run: just format-check
 
@@ -86,7 +86,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.3.0
+        uses: astral-sh/setup-uv@1edb52594c857e2b5b13128931090f0640537287 # v5.3.0
         with:
           version: "latest"
       - name: Run zizmor 🌈

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR Title
-        uses: deepakputhraya/action-pr-title@v1.0.2
+        uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 # v1.0.2
         with:
           allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: " # title should start with the given prefix
 
@@ -30,7 +30,7 @@ jobs:
           configuration-path: .github/other-configurations/labeller.yml
           sync-labels: true
       - name: Add Size Labels
-        uses: pascalgn/size-label-action@v0.5.5
+        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Sync labels
-        uses: micnncim/action-label-syncer@v1.3.0
+        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}

--- a/Justfile
+++ b/Justfile
@@ -2,9 +2,11 @@
 # Prettier
 # ------------------------------------------------------------------------------
 
+# Check all files with prettier
 prettier-check:
     prettier . --check
 
+# Format all files with prettier
 prettier-format:
     prettier . --check --write
 
@@ -12,18 +14,53 @@ prettier-format:
 # Justfile
 # ------------------------------------------------------------------------------
 
+# Format Justfile
 format:
     just --fmt --unstable
 
+# Check Justfile formatting
 format-check:
     just --fmt --check --unstable
 
 # ------------------------------------------------------------------------------
-# gitleaks
+# Gitleaks
 # ------------------------------------------------------------------------------
 
+# Run gitleaks detection
 gitleaks-detect:
-    gitleaks detect --source . > /dev/null
+    gitleaks detect --source .
+
+# ------------------------------------------------------------------------------
+# Lefthook
+# ------------------------------------------------------------------------------
+
+# Validate lefthook config
+lefthook-validate:
+    lefthook validate
+
+# ------------------------------------------------------------------------------
+# Zizmor
+# ------------------------------------------------------------------------------
+
+# Run zizmor checking
+zizmor-check:
+    zizmor .
+
+# ------------------------------------------------------------------------------
+# Pinact
+# ------------------------------------------------------------------------------
+
+# Run pinact
+pinact-run:
+    pinact run -c .github/other-configurations/pinact.yml
+
+# Run pinact checking
+pinact-check:
+    pinact run -c .github/other-configurations/pinact.yml --verify --check
+
+# Run pinact update
+pinact-update:
+    pinact run -c .github/other-configurations/pinact.yml --update
 
 # ------------------------------------------------------------------------------
 # Git Hooks
@@ -31,6 +68,4 @@ gitleaks-detect:
 
 # Install pre commit hook to run on all commits
 install-git-hooks:
-    cp -f githooks/pre-commit .git/hooks/pre-commit
-    cp -f githooks/post-commit .git/hooks/post-commit
-    chmod ug+x .git/hooks/*
+    lefthook install -f


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces several updates to configuration files and workflows, focusing on pinning action versions for better reproducibility, adding new tasks and commands to the `Justfile`, and integrating a new tool (`pinact`) for workflow management. Below is a summary of the most important changes:

### Workflow Improvements

* Added a new configuration file `.github/other-configurations/pinact.yml` for the `pinact` tool, including schema validation and ignored actions. This file enables better control over GitHub Actions workflows.
* Updated action references in `.github/workflows/code-checks.yml`, `.github/workflows/pull-request-tasks.yml`, and `.github/workflows/sync-labels.yml` to use specific commit SHAs instead of version tags, ensuring reproducibility. Examples include:
  - `super-linter/slim` updated to `4e8a7c2b...`
  - `UmbrellaDocs/action-linkspector` updated to `c6d4525e...`
  - `deepakputhraya/action-pr-title` updated to `3864bebc...`

### Justfile Enhancements

* Added new commands to the `Justfile` for tasks like running `pinact`, validating `lefthook` configurations, and performing checks with tools like `zizmor` and `gitleaks`. These additions enhance automation and standardization for development workflows.
* Replaced manual git hook installation with `lefthook install` for improved manageability.

These changes collectively improve the maintainability, reproducibility, and automation of the project's workflows.
