### PR TITLE
chore: Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,8 @@ updates:
     commit-message:
       prefix: "deps(github-actions)"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       github-actions:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       prefix: "deps(github-actions)"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       github-actions:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Dependabot configuration to modify the schedule for dependency updates. The change shifts from a daily interval to a cron-based schedule for more precise control over update timing.

Configuration changes:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L8-R9): Replaced the `interval` and `time` fields with a `cronjob` field to schedule updates at "30 7 * * *" (7:30 AM UTC daily).