### PR TITLE
chore: Update Dependabot Groups and Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -7,11 +8,15 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          - "super-linter/*"
         update-types:
           - "patch"
           - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` file to enhance the configuration for Dependabot. The changes include adding a timezone for the update schedule, refining the grouping of updates, and excluding specific patterns.

Enhancements to Dependabot configuration:

* Added `timezone: "Europe/London"` to the update schedule to specify the time zone for cron-based updates.
* In the `github-actions` group, added `applies-to: "version-updates"` to specify the scope of the group.
* Introduced `exclude-patterns` under the `github-actions` group to exclude updates matching the pattern `"super-linter/*"`.