### PR TITLE
chore: Remove Pinact Configuration

### DIFF
--- a/.github/other-configurations/pinact.yml
+++ b/.github/other-configurations/pinact.yml
@@ -1,9 +1,0 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
-# pinact - https://github.com/suzuki-shunsuke/pinact
-version: 3
-
-ignore_actions:
-  - name: actions/.*
-    ref: .*
-  - name: github/codeql-action/.*
-    ref: .*

--- a/Justfile
+++ b/Justfile
@@ -52,15 +52,15 @@ zizmor-check:
 
 # Run pinact
 pinact-run:
-    pinact run -c .github/other-configurations/pinact.yml
+    pinact run
 
 # Run pinact checking
 pinact-check:
-    pinact run -c .github/other-configurations/pinact.yml --verify --check
+    pinact run --verify --check
 
 # Run pinact update
 pinact-update:
-    pinact run -c .github/other-configurations/pinact.yml --update
+    pinact run --update
 
 # ------------------------------------------------------------------------------
 # Git Hooks


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes the configuration file for Pinact and updates the corresponding commands in the `Justfile` to no longer reference it. The changes simplify the setup by eliminating the need for an external configuration file.

### Removal of Pinact configuration:

* [`.github/other-configurations/pinact.yml`](diffhunk://#diff-c2e684c61036562879b1062fb69ab67d446e19354f7a45ef92b14f611a051bc5L1-L9): Deleted the Pinact configuration file, which included version settings and ignored actions.

### Updates to Pinact commands:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL55-R63): Modified the `pinact-run`, `pinact-check`, and `pinact-update` commands to remove the `-c .github/other-configurations/pinact.yml` option, as the configuration file is no longer needed.