### PR TITLE
chore: Fix Zizmor SARIF Command

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -87,15 +87,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@1edb52594c857e2b5b13128931090f0640537287 # v5.3.0
-        with:
-          version: "latest"
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+      - name: Set up Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Run zizmor 🌈
-        run: uvx zizmor --format sarif . > results.sarif
+        run: just zizmor-check-sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.10
+        uses: github/codeql-action/upload-sarif@v3.28.17
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/Justfile
+++ b/Justfile
@@ -44,7 +44,11 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    zizmor . --pedantic --persona=pedantic
+    uvx zizmor . --persona=pedantic
+
+# Run zizmor checking with sarif output
+zizmor-check-sarif:
+    uvx zizmor . --persona=pedantic --format sarif > results.sarif
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the workflow configuration and the `Justfile` to improve dependency management and streamline the execution of code checks. The most important changes include updating the `setup-uv` action to a newer version, adding a new setup step for `Just`, and replacing direct `uvx` commands with `Just` tasks for consistency.

### Workflow updates:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L90-R98): Updated `setup-uv` action to version `v6.0.1` and added a new step to set up `Just` using the `extractions/setup-just` action. Replaced the direct `uvx zizmor` command with the `just zizmor-check-sarif` task for running checks, and updated the `upload-sarif` action to version `v3.28.17`.

### `Justfile` updates:
* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL47-R51): Added a new `zizmor-check-sarif` task to generate SARIF output using `uvx`, and modified the existing `zizmor-check` task to ensure consistency with the new workflow setup.